### PR TITLE
Update css-loader peer dependency to 0.25

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "homepage": "https://github.com/smithad15/css-to-string-loader#readme",
   "devDependencies": {},
   "peerDependencies": {
-    "css-loader": "^0.23.1"
+    "css-loader": "^0.25.0"
   },
   "dependencies": {
     "loader-utils": "^0.2.15"


### PR DESCRIPTION
Closes https://github.com/smithad15/css-to-string-loader/issues/1
